### PR TITLE
Add support for RNG activities

### DIFF
--- a/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
@@ -355,7 +355,7 @@ public class BankedCalculator extends JPanel
 		item.setSelectedActivity(a);
 
 		// Cascade activity changes if necessary.
-		if (config.cascadeBankedXp() && (old.getLinkedItem() != a.getLinkedItem()))
+		if (config.cascadeBankedXp() && a.shouldUpdateLinked(old))
 		{
 			// Update Linked Map
 			linkedMap.remove(old.getLinkedItem(), i);

--- a/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
@@ -303,7 +303,7 @@ public class BankedCalculator extends JPanel
 		{
 			// Account for activities that output multiple of a specific item per action
 			final ItemStack output = entry.getKey().getSelectedActivity().getOutput();
-			return entry.getValue() * (output != null ? output.getQty() : 1);
+			return (int) (entry.getValue() * (output != null ? output.getQty() : 1));
 		}).sum();
 
 		return qty + linkedQty;

--- a/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
@@ -222,7 +222,7 @@ public class BankedCalculator extends JPanel
 			final int level = config.limitToCurrentLevel() ? skillLevel : -1;
 			if (a == null || (level > 0 && level < a.getLevel()))
 			{
-				final List<Activity> activities = Activity.getByExperienceItem(item, level);
+				final List<Activity> activities = Activity.getByExperienceItem(item, level, config.includeRngActivities());
 				if (activities.size() == 0)
 				{
 					item.setSelectedActivity(null);

--- a/src/main/java/thestonedturtle/bankedexperience/BankedExperienceConfig.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedExperienceConfig.java
@@ -72,4 +72,15 @@ public interface BankedExperienceConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "includeRngActivities",
+		name = "Include RNG activities",
+		description = "Toggles whether activities with exp values that are effected by RNG will be shown in the calculator",
+		position = 7
+	)
+	default boolean includeRngActivities()
+	{
+		return false;
+	}
 }

--- a/src/main/java/thestonedturtle/bankedexperience/components/GridItem.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/GridItem.java
@@ -56,6 +56,9 @@ public class GridItem extends JLabel
 	private static final Color IGNORED_BACKGROUND = new Color(90, 0, 0);
 	private static final Color IGNORED_HOVER_BACKGROUND = new Color(120, 0, 0);
 
+	private static final Color RNG_BACKGROUND = new Color(140, 90, 0);
+	private static final Color RNG_HOVER_BACKGROUND = new Color(186, 120, 0);
+
 	@Setter
 	private SelectionListener selectionListener;
 
@@ -64,6 +67,7 @@ public class GridItem extends JLabel
 
 	private boolean selected = false;
 	private boolean ignored = false;
+	private boolean rng;
 
 	private final JMenuItem IGNORE_OPTION = new JMenuItem(IGNORE);
 
@@ -74,7 +78,7 @@ public class GridItem extends JLabel
 		this.bankedItem = item;
 
 		this.setOpaque(true);
-		this.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		this.setBackground(getBackgroundColor());
 		this.setBorder(BorderFactory.createEmptyBorder(5, 0, 2, 0));
 
 		this.setVerticalAlignment(SwingConstants.CENTER);
@@ -137,12 +141,12 @@ public class GridItem extends JLabel
 
 	private Color getBackgroundColor()
 	{
-		return ignored ? IGNORED_BACKGROUND : (selected ? SELECTED_BACKGROUND : UNSELECTED_BACKGROUND);
+		return ignored ? IGNORED_BACKGROUND : (rng ? RNG_BACKGROUND : (selected ? SELECTED_BACKGROUND : UNSELECTED_BACKGROUND));
 	}
 
 	private Color getHoverBackgroundColor()
 	{
-		return ignored ? IGNORED_HOVER_BACKGROUND : (selected ? SELECTED_HOVER_BACKGROUND : UNSELECTED_HOVER_BACKGROUND);
+		return ignored ? IGNORED_HOVER_BACKGROUND : (rng ? RNG_HOVER_BACKGROUND : (selected ? SELECTED_HOVER_BACKGROUND : UNSELECTED_HOVER_BACKGROUND));
 	}
 
 	void select()
@@ -166,6 +170,12 @@ public class GridItem extends JLabel
 	public void updateToolTip(final float modifier)
 	{
 		this.setToolTipText(buildToolTip(modifier));
+		final Activity selectedActivity = bankedItem.getItem().getSelectedActivity();
+		if (selectedActivity != null)
+		{
+			this.rng = selectedActivity.isRngActivity();
+			this.setBackground(getBackgroundColor());
+		}
 	}
 
 	private String buildToolTip(final float modifier)

--- a/src/main/java/thestonedturtle/bankedexperience/components/ModifyPanel.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/ModifyPanel.java
@@ -234,7 +234,7 @@ public class ModifyPanel extends JPanel
 		final float xpFactor = this.calc.getXpFactor();
 
 		final int level = calc.getConfig().limitToCurrentLevel() ? calc.getSkillLevel() : -1;
-		final List<Activity> activities = Activity.getByExperienceItem(bankedItem.getItem(), level);
+		final List<Activity> activities = Activity.getByExperienceItem(bankedItem.getItem(), level, calc.getConfig().includeRngActivities());
 		if (activities == null || activities.size() == 0)
 		{
 			final JLabel unusable = new JLabel("Unusable at current level");

--- a/src/main/java/thestonedturtle/bankedexperience/components/ModifyPanel.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/ModifyPanel.java
@@ -249,7 +249,7 @@ public class ModifyPanel extends JPanel
 		{
 			final Activity a = activities.get(0);
 
-			final int qty =  a.getOutput() == null ? 1 : a.getOutput().getQty();
+			final int qty =  a.getOutput() == null ? 1 : (int) a.getOutput().getQty();
 			final boolean stackable = a.getOutputItemInfo() == null ? qty > 1 : a.getOutputItemInfo().isStackable();
 			final AsyncBufferedImage img = itemManager.getImage(a.getIcon(), qty, stackable);
 			final ImageIcon icon = new ImageIcon(img);
@@ -345,7 +345,7 @@ public class ModifyPanel extends JPanel
 
 			for (final ItemStack s : secondaries.getItems())
 			{
-				final int required = s.getQty() * amount;
+				final int required = (int) (s.getQty() * amount);
 				final int available = this.calc.getItemQtyFromBank(s.getId());
 				container.add(createSecondaryItemLabel(s.getId(), available, required));
 			}

--- a/src/main/java/thestonedturtle/bankedexperience/data/Activity.java
+++ b/src/main/java/thestonedturtle/bankedexperience/data/Activity.java
@@ -874,4 +874,32 @@ public enum Activity
 	{
 		return experienceItem.isIgnoreBonus() ? xp : xp * modifier;
 	}
+
+	private static boolean isOneNull(final Object a, final Object b)
+	{
+		return (a == null && b != null) || (a != null && b == null);
+	}
+
+	public boolean shouldUpdateLinked(final Activity old)
+	{
+		if (old.getLinkedItem() != linkedItem)
+		{
+			return true;
+		}
+
+		final ItemStack oldOutput = old.getOutput();
+		// If both are null and the item hasn't change it shouldn't be updated
+		if (oldOutput == null && output == null)
+		{
+			return false;
+		}
+
+		// If one was null an update should happen
+		if (isOneNull(oldOutput, output))
+		{
+			return true;
+		}
+
+		return oldOutput.getQty() != output.getQty() || oldOutput.getId() != output.getId();
+	}
 }

--- a/src/main/java/thestonedturtle/bankedexperience/data/Activity.java
+++ b/src/main/java/thestonedturtle/bankedexperience/data/Activity.java
@@ -522,6 +522,26 @@ public enum Activity
 		ExperienceItem.GOLD_BAR, null, new ItemStack(ItemID.GOLD_BRACELET, 1)),
 	GOLD_AMULET_U(ItemID.GOLD_AMULET_U, "Gold amulet (u)", 8, 30,
 		ExperienceItem.GOLD_BAR, null, new ItemStack(ItemID.GOLD_AMULET_U, 1)),
+	// RNG section
+	// Soda Ash
+	MOLTEN_GLASS(ItemID.MOLTEN_GLASS, "Furnace", 1, 10,
+		ExperienceItem.SODA_ASH, null, new ItemStack(ItemID.MOLTEN_GLASS, 1)),
+	MOLTEN_GLASS_SPELL(ItemID.MOLTEN_GLASS, "SGM [1.3x]", 1, 10, true,
+		ExperienceItem.SODA_ASH, Secondaries.BUCKET_OF_SAND, new ItemStack(ItemID.MOLTEN_GLASS, 1.3)),
+	// Seaweed
+	SODA_ASH(ItemID.SODA_ASH, "Soda Ash", 1, 0,
+		ExperienceItem.SEAWEED, null, new ItemStack(ItemID.SODA_ASH, 1)),
+	S_MOLTEN_GLASS_SPELL(ItemID.MOLTEN_GLASS, "SGM [1.3x]", 1, 10, true,
+		ExperienceItem.SEAWEED, Secondaries.BUCKET_OF_SAND, new ItemStack(ItemID.MOLTEN_GLASS, 1.3)),
+	// Giant Seaweed
+	G_SODA_ASH(ItemID.SODA_ASH, "Soda Ash", 1, 0,
+		ExperienceItem.GIANT_SEAWEED, null, new ItemStack(ItemID.SODA_ASH, 6)),
+	MOLTEN_GLASS_SPELL_18_PICKUP(ItemID.MOLTEN_GLASS, "SGM 18:3 Pickup [1.6x]", 1, 60,  true,// XP per seaweed
+		ExperienceItem.GIANT_SEAWEED, Secondaries.BUCKET_OF_SAND_6, new ItemStack(ItemID.MOLTEN_GLASS, 9.6)),
+	MOLTEN_GLASS_SPELL_18(ItemID.MOLTEN_GLASS, "SGM 18:3 [1.488x]", 1, 60,  true,// XP per seaweed
+		ExperienceItem.GIANT_SEAWEED, Secondaries.BUCKET_OF_SAND_6, new ItemStack(ItemID.MOLTEN_GLASS, 8.928)),
+	MOLTEN_GLASS_SPELL_12(ItemID.MOLTEN_GLASS, "SGM 12:2 [1.45x]", 1, 60,  true,// XP per seaweed
+		ExperienceItem.GIANT_SEAWEED, Secondaries.BUCKET_OF_SAND_6, new ItemStack(ItemID.MOLTEN_GLASS, 8.7)),
 	/**
 	 * Smithing
 	 */
@@ -767,6 +787,7 @@ public enum Activity
 	private final String name;
 	private final int level;
 	private final double xp;
+	private final boolean rngActivity;
 	private final ExperienceItem experienceItem;
 	private final Skill skill;
 	@Nullable
@@ -791,7 +812,6 @@ public enum Activity
 		ITEM_MAP = map.build();
 		BANKABLE_SKILLS = set.build();
 	}
-
 	Activity(
 		final int icon,
 		final String name,
@@ -801,11 +821,25 @@ public enum Activity
 		@Nullable final Secondaries secondaries,
 		@Nullable final ItemStack output)
 	{
+		this(icon, name, level, xp, false, experienceItem, secondaries, output);
+	}
+
+	Activity(
+		final int icon,
+		final String name,
+		final int level,
+		final double xp,
+		final boolean rngActivity,
+		final ExperienceItem experienceItem,
+		@Nullable final Secondaries secondaries,
+		@Nullable final ItemStack output)
+	{
 		this.icon = icon;
 		this.name = name;
 		this.skill = experienceItem.getSkill();
 		this.level = level;
 		this.xp = xp;
+		this.rngActivity = rngActivity;
 		this.experienceItem = experienceItem;
 		this.secondaries = secondaries;
 		this.output = output;
@@ -832,9 +866,10 @@ public enum Activity
 	 * Get all Activities for this ExperienceItem limited to level
 	 * @param item ExperienceItem to check for
 	 * @param limitLevel Level to check Activitiy requirements against. -1/0 value disables limits
+	 * @param rng boolean flag about whether to include RNG activities
 	 * @return an empty Collection if no activities
 	 */
-	public static List<Activity> getByExperienceItem(final ExperienceItem item, final int limitLevel)
+	public static List<Activity> getByExperienceItem(final ExperienceItem item, final int limitLevel, final boolean rng)
 	{
 		// Return as list to allow getting by index
 		final List<Activity> l = getByExperienceItem(item);
@@ -843,7 +878,15 @@ public enum Activity
 			return l;
 		}
 
-		return l.stream().filter(a -> a.getLevel() <= limitLevel).collect(Collectors.toList());
+		return l.stream().filter(a ->
+		{
+			if (!rng && a.isRngActivity())
+			{
+				return false;
+			}
+
+			return a.getLevel() <= limitLevel;
+		}).collect(Collectors.toList());
 	}
 
 	/**

--- a/src/main/java/thestonedturtle/bankedexperience/data/ExperienceItem.java
+++ b/src/main/java/thestonedturtle/bankedexperience/data/ExperienceItem.java
@@ -226,6 +226,10 @@ public enum ExperienceItem
 	DRAGONSTONE(ItemID.DRAGONSTONE, Skill.CRAFTING, "Gems"),
 	ONYX(ItemID.ONYX, Skill.CRAFTING, "Gems"),
 	ZENYTE(ItemID.ZENYTE, Skill.CRAFTING, "Gems"),
+	// RNG
+	SEAWEED(ItemID.SEAWEED, Skill.CRAFTING, "Misc"),
+	SODA_ASH(ItemID.SODA_ASH, Skill.CRAFTING, "Misc"),
+	GIANT_SEAWEED(ItemID.GIANT_SEAWEED, Skill.CRAFTING, "Misc"),
 	/**
 	 * Smithing
 	 */
@@ -349,7 +353,8 @@ public enum ExperienceItem
 	private final int itemID;
 	private final Skill skill;
 	private final String category;
-	private boolean ignoreBonus;
+	private final boolean ignoreBonus;
+	private final boolean rngItem;
 
 	@Setter
 	// Stores the item composition info we use since we don't operate on the game thread
@@ -370,17 +375,23 @@ public enum ExperienceItem
 		}
 	}
 
-	ExperienceItem(int itemID, Skill skill, String category, boolean ignoreBonus)
+	ExperienceItem(int itemID, Skill skill, String category, boolean ignoreBonus, boolean rngItem)
 	{
 		this.itemID = itemID;
 		this.category = category;
 		this.skill = skill;
 		this.ignoreBonus = ignoreBonus;
+		this.rngItem = rngItem;
+	}
+
+	ExperienceItem(int itemID, Skill skill, String category, boolean ignoreBonus)
+	{
+		this(itemID, skill, category, ignoreBonus, false);
 	}
 
 	ExperienceItem(int itemID, Skill skill, String category)
 	{
-		this(itemID, skill, category, false);
+		this(itemID, skill, category, false, false);
 	}
 
 	public static Collection<ExperienceItem> getBySkill(Skill skill)

--- a/src/main/java/thestonedturtle/bankedexperience/data/ItemStack.java
+++ b/src/main/java/thestonedturtle/bankedexperience/data/ItemStack.java
@@ -32,5 +32,5 @@ import lombok.Data;
 public class ItemStack
 {
 	private int id;
-	private int qty;
+	private double qty;
 }

--- a/src/main/java/thestonedturtle/bankedexperience/data/Secondaries.java
+++ b/src/main/java/thestonedturtle/bankedexperience/data/Secondaries.java
@@ -99,6 +99,8 @@ public enum Secondaries
 	EARTH_ORB(new ItemStack(ItemID.EARTH_ORB, 1)),
 	FIRE_ORB(new ItemStack(ItemID.FIRE_ORB, 1)),
 	AIR_ORB(new ItemStack(ItemID.AIR_ORB, 1)),
+	BUCKET_OF_SAND(new ItemStack(ItemID.BUCKET_OF_SAND, 1)),
+	BUCKET_OF_SAND_6(new ItemStack(ItemID.BUCKET_OF_SAND, 6)),
 	/**
 	 * Construction
 	 */


### PR DESCRIPTION
Adds support for RNG activities by adding Giant seaweed/Superglass Make support.

Closes #12 