### PR TITLE
Bulk Ignore & Include Items

### DIFF
--- a/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
@@ -151,7 +151,7 @@ public class BankedCalculator extends JPanel
 			}
 		}));
 
-		this.ignoreAllBtn = new JButton("Ignore all");
+		this.ignoreAllBtn = new JButton("Ignore All");
 		ignoreAllBtn.setFocusable(false);
 		ignoreAllBtn.addMouseListener((new MouseAdapter()
 		{
@@ -165,7 +165,7 @@ public class BankedCalculator extends JPanel
 			}
 		}));
 
-		this.includeAllBtn = new JButton("Include all");
+		this.includeAllBtn = new JButton("Include All");
 		includeAllBtn.setFocusable(false);
 		includeAllBtn.addMouseListener((new MouseAdapter()
 		{

--- a/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
@@ -664,14 +664,11 @@ public class BankedCalculator extends JPanel
 		updateLinkedItems(item.getItem().getSelectedActivity());
 	}
 
-
 	private void toggleIgnoreBankedItem(BankedItem item)
 	{
 		boolean ignore = !ignoredItems.contains(item.getItem().name());
 		ignoreBankedItem(item, ignore);
 	}
-
-
 
 	public void setIgnoreAllItems(boolean ignored)
 	{

--- a/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
@@ -191,10 +191,19 @@ public class BankedCalculator extends JPanel
 			@Override
 			public boolean ignored(BankedItem item)
 			{
-				addBankedItemToIgnore(item);
+				// Save ignored status
+				final String name = item.getItem().name();
+				final boolean existed = ignoredItems.remove(name);
+				if (!existed)
+				{
+					ignoredItems.add(name);
+				}
+				config.ignoredItems(Text.toCSV(ignoredItems));
+
 				// Update UI
 				updateLinkedItems(item.getItem().getSelectedActivity());
 				calculateBankedXpTotal();
+
 				return true;
 			}
 		});
@@ -685,22 +694,20 @@ public class BankedCalculator extends JPanel
 		recreateItemGrid();
 	}
 
-	private void addBankedItemToIgnore(BankedItem item) {
-		final String name = item.getItem().name();
-		final boolean existed = ignoredItems.remove(name);
-		if (!existed)
-		{
-			ignoredItems.add(name);
-		}
-		config.ignoredItems(Text.toCSV(ignoredItems));
-	}
-
 	private void setIgnoreAllItems(Boolean ignored) {
 		for (final GridItem i : itemGrid.getPanelMap().values())
 		{
 			i.setIgnore(ignored);
+
+			final String name = i.getBankedItem().getItem().name();
+			if (ignored) {
+				ignoredItems.add(name);
+			} else {
+				ignoredItems.remove(name);
+			}
 			updateLinkedItems(i.getBankedItem().getItem().getSelectedActivity());
 		}
+		config.ignoredItems(Text.toCSV(ignoredItems));
 		calculateBankedXpTotal();
 	}
 }

--- a/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
@@ -26,6 +26,8 @@ package thestonedturtle.bankedexperience;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+
+import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.text.DecimalFormat;
@@ -94,6 +96,9 @@ public class BankedCalculator extends JPanel
 	private ExpandableSection secondarySection;
 	private final JButton refreshBtn;
 
+	private final JButton ignoreAllBtn;
+	private final JButton includeAllBtn;
+
 	// Store items from all sources in the same map
 	private final Map<Integer, Integer> currentMap = new HashMap<>();
 	// keep sources separate for recreating currentMap when one updates
@@ -146,6 +151,35 @@ public class BankedCalculator extends JPanel
 			}
 		}));
 
+		this.ignoreAllBtn = new JButton("Ignore all");
+		ignoreAllBtn.setFocusable(false);
+		// setIgnoreAllItems
+		ignoreAllBtn.addMouseListener((new MouseAdapter()
+		{
+			@Override
+			public void mousePressed(MouseEvent e)
+			{
+				if (e.getButton() == MouseEvent.BUTTON1)
+				{
+					setIgnoreAllItems(true);
+				}
+			}
+		}));
+
+		this.includeAllBtn = new JButton("Include all");
+		includeAllBtn.setFocusable(false);
+		includeAllBtn.addMouseListener((new MouseAdapter()
+		{
+			@Override
+			public void mousePressed(MouseEvent e)
+			{
+				if (e.getButton() == MouseEvent.BUTTON1)
+				{
+					setIgnoreAllItems(false);
+				}
+			}
+		}));
+
 		itemGrid.setSelectionListener(new SelectionListener()
 		{
 			@Override
@@ -158,19 +192,10 @@ public class BankedCalculator extends JPanel
 			@Override
 			public boolean ignored(BankedItem item)
 			{
-				// Save ignored status
-				final String name = item.getItem().name();
-				final boolean existed = ignoredItems.remove(name);
-				if (!existed)
-				{
-					ignoredItems.add(name);
-				}
-				config.ignoredItems(Text.toCSV(ignoredItems));
-
+				addBankedItemToIgnore(item);
 				// Update UI
 				updateLinkedItems(item.getItem().getSelectedActivity());
 				calculateBankedXpTotal();
-
 				return true;
 			}
 		});
@@ -303,6 +328,13 @@ public class BankedCalculator extends JPanel
 					add(secondarySection);
 				}
 			}
+		}
+
+		if (config.showBulkActions()) {
+			JPanel bulkActionPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
+			bulkActionPanel.add(this.includeAllBtn);
+			bulkActionPanel.add(this.ignoreAllBtn);
+			add(bulkActionPanel);
 		}
 
 		add(refreshBtn);
@@ -652,5 +684,24 @@ public class BankedCalculator extends JPanel
 		// If the item grid wasn't added then the boost input is not visible
 		recreateBankedItemMap();
 		recreateItemGrid();
+	}
+
+	private void addBankedItemToIgnore(BankedItem item) {
+		final String name = item.getItem().name();
+		final boolean existed = ignoredItems.remove(name);
+		if (!existed)
+		{
+			ignoredItems.add(name);
+		}
+		config.ignoredItems(Text.toCSV(ignoredItems));
+	}
+
+	private void setIgnoreAllItems(Boolean ignored) {
+		for (final GridItem i : itemGrid.getPanelMap().values())
+		{
+			i.setIgnore(ignored);
+			updateLinkedItems(i.getBankedItem().getItem().getSelectedActivity());
+		}
+		calculateBankedXpTotal();
 	}
 }

--- a/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
@@ -27,7 +27,6 @@ package thestonedturtle.bankedexperience;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
-import java.awt.FlowLayout;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.text.DecimalFormat;
@@ -299,11 +298,6 @@ public class BankedCalculator extends JPanel
 				{
 					add(secondarySection);
 				}
-			}
-
-			if (config.showBulkActions()) {
-				JPanel bulkActionPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
-				add(bulkActionPanel);
 			}
 		}
 

--- a/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
@@ -27,7 +27,7 @@ package thestonedturtle.bankedexperience;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
-import java.awt.*;
+import java.awt.FlowLayout;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.text.DecimalFormat;
@@ -153,7 +153,6 @@ public class BankedCalculator extends JPanel
 
 		this.ignoreAllBtn = new JButton("Ignore all");
 		ignoreAllBtn.setFocusable(false);
-		// setIgnoreAllItems
 		ignoreAllBtn.addMouseListener((new MouseAdapter()
 		{
 			@Override
@@ -328,13 +327,13 @@ public class BankedCalculator extends JPanel
 					add(secondarySection);
 				}
 			}
-		}
 
-		if (config.showBulkActions()) {
-			JPanel bulkActionPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
-			bulkActionPanel.add(this.includeAllBtn);
-			bulkActionPanel.add(this.ignoreAllBtn);
-			add(bulkActionPanel);
+			if (config.showBulkActions()) {
+				JPanel bulkActionPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
+				bulkActionPanel.add(this.includeAllBtn);
+				bulkActionPanel.add(this.ignoreAllBtn);
+				add(bulkActionPanel);
+			}
 		}
 
 		add(refreshBtn);

--- a/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
@@ -26,7 +26,6 @@ package thestonedturtle.bankedexperience;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.text.DecimalFormat;

--- a/src/main/java/thestonedturtle/bankedexperience/BankedExperienceConfig.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedExperienceConfig.java
@@ -87,7 +87,7 @@ public interface BankedExperienceConfig extends Config
 	@ConfigItem(
 			keyName = "showBulkActions",
 			name = "Show Ignore/Include All Buttons",
-			description = "Toggles the Ignore All and Include All buttons",
+			description = "Toggles the Ignore All and Include All menu options",
 			position = 8
 	)
 	default boolean showBulkActions()

--- a/src/main/java/thestonedturtle/bankedexperience/BankedExperienceConfig.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedExperienceConfig.java
@@ -85,6 +85,17 @@ public interface BankedExperienceConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "showBulkActions",
+			name = "Show Ignore/Include All Buttons",
+			description = "Toggles the Ignore All and Include All buttons",
+			position = 8
+	)
+	default boolean showBulkActions()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "ignoredItems",
 		name = "",
 		description = "",

--- a/src/main/java/thestonedturtle/bankedexperience/BankedExperienceConfig.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedExperienceConfig.java
@@ -85,17 +85,6 @@ public interface BankedExperienceConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "showBulkActions",
-			name = "Show Ignore/Include All Buttons",
-			description = "Toggles the Ignore All and Include All menu options",
-			position = 8
-	)
-	default boolean showBulkActions()
-	{
-		return true;
-	}
-
-	@ConfigItem(
 		keyName = "ignoredItems",
 		name = "",
 		description = "",

--- a/src/main/java/thestonedturtle/bankedexperience/components/GridItem.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/GridItem.java
@@ -81,7 +81,7 @@ public class GridItem extends JLabel
 	private final JMenuItem INCLUDE_ALL_OPTION = new JMenuItem(INCLUDE_ALL);
 
 
-	GridItem(final BankedItem item, final AsyncBufferedImage icon, final int amount, final Collection<Modifier> modifiers, final boolean ignore, Consumer<Boolean> bulkIgnoreCallback)
+	GridItem(final BankedItem item, final AsyncBufferedImage icon, final int amount, final Collection<Modifier> modifiers, final boolean ignore, Consumer<Boolean> bulkIgnoreCallback, final boolean showBulkActions)
 	{
 		super("");
 
@@ -139,19 +139,22 @@ public class GridItem extends JLabel
 			setIgnore(!ignored);
 		});
 
-		IGNORE_ALL_OPTION.addActionListener(e -> {
-			bulkIgnoreCallback.accept(true);
-		});
-
-		INCLUDE_ALL_OPTION.addActionListener(e -> {
-			bulkIgnoreCallback.accept(false);
-		});
 
 		final JPopupMenu popupMenu = new JPopupMenu();
 		popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
 		popupMenu.add(IGNORE_OPTION);
-		popupMenu.add(INCLUDE_ALL_OPTION);
-		popupMenu.add(IGNORE_ALL_OPTION);
+		if (showBulkActions) {
+			IGNORE_ALL_OPTION.addActionListener(e -> {
+				bulkIgnoreCallback.accept(true);
+			});
+
+			INCLUDE_ALL_OPTION.addActionListener(e -> {
+				bulkIgnoreCallback.accept(false);
+			});
+
+			popupMenu.add(INCLUDE_ALL_OPTION);
+			popupMenu.add(IGNORE_ALL_OPTION);
+		}
 
 		this.setComponentPopupMenu(popupMenu);
 	}

--- a/src/main/java/thestonedturtle/bankedexperience/components/GridItem.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/GridItem.java
@@ -131,15 +131,12 @@ public class GridItem extends JLabel
 
 		IGNORE_OPTION.addActionListener(e ->
 		{
-			ignored = !ignored;
 			if (selectionListener != null && !selectionListener.ignored(item))
 			{
-				ignored = !ignored;
 				return;
 			}
 
-			IGNORE_OPTION.setText(ignored ? INCLUDE : IGNORE);
-			setBackground(getBackgroundColor());
+			setIgnore(!ignored);
 		});
 
 		IGNORE_ALL_OPTION.addActionListener(e -> {

--- a/src/main/java/thestonedturtle/bankedexperience/components/GridItem.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/GridItem.java
@@ -81,7 +81,9 @@ public class GridItem extends JLabel
 	private final JMenuItem INCLUDE_ALL_OPTION = new JMenuItem(INCLUDE_ALL);
 
 
-	GridItem(final BankedItem item, final AsyncBufferedImage icon, final int amount, final Collection<Modifier> modifiers, final boolean ignore, Consumer<Boolean> bulkIgnoreCallback, final boolean showBulkActions)
+	GridItem(final BankedItem item, final AsyncBufferedImage icon, final int amount,
+			 final Collection<Modifier> modifiers, final boolean ignore, Consumer<Boolean> bulkIgnoreCallback,
+			 final boolean showBulkActions)
 	{
 		super("");
 

--- a/src/main/java/thestonedturtle/bankedexperience/components/GridItem.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/GridItem.java
@@ -200,4 +200,10 @@ public class GridItem extends JLabel
 
 		return tip + "</html>";
 	}
+
+	public void setIgnore(Boolean ignored) {
+		this.ignored = ignored;
+		IGNORE_OPTION.setText(ignored ? INCLUDE : IGNORE);
+		this.setBackground(this.getBackgroundColor());
+	}
 }

--- a/src/main/java/thestonedturtle/bankedexperience/components/GridItem.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/GridItem.java
@@ -75,15 +75,11 @@ public class GridItem extends JLabel
 	private boolean rng;
 
 	private final JMenuItem IGNORE_OPTION = new JMenuItem(IGNORE);
-
 	private final JMenuItem IGNORE_ALL_OPTION = new JMenuItem(IGNORE_ALL);
-
 	private final JMenuItem INCLUDE_ALL_OPTION = new JMenuItem(INCLUDE_ALL);
 
-
 	GridItem(final BankedItem item, final AsyncBufferedImage icon, final int amount,
-			 final Collection<Modifier> modifiers, final boolean ignore, Consumer<Boolean> bulkIgnoreCallback,
-			 final boolean showBulkActions)
+			 final Collection<Modifier> modifiers, final boolean ignore, Consumer<Boolean> bulkIgnoreCallback)
 	{
 		super("");
 
@@ -133,30 +129,29 @@ public class GridItem extends JLabel
 
 		IGNORE_OPTION.addActionListener(e ->
 		{
+			ignored = !ignored;
 			if (selectionListener != null && !selectionListener.ignored(item))
 			{
+				ignored = !ignored;
 				return;
 			}
 
-			setIgnore(!ignored);
+			setIgnore(ignored);
 		});
 
+		IGNORE_ALL_OPTION.addActionListener(e -> {
+			bulkIgnoreCallback.accept(true);
+		});
+
+		INCLUDE_ALL_OPTION.addActionListener(e -> {
+			bulkIgnoreCallback.accept(false);
+		});
 
 		final JPopupMenu popupMenu = new JPopupMenu();
 		popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
 		popupMenu.add(IGNORE_OPTION);
-		if (showBulkActions) {
-			IGNORE_ALL_OPTION.addActionListener(e -> {
-				bulkIgnoreCallback.accept(true);
-			});
-
-			INCLUDE_ALL_OPTION.addActionListener(e -> {
-				bulkIgnoreCallback.accept(false);
-			});
-
-			popupMenu.add(INCLUDE_ALL_OPTION);
-			popupMenu.add(IGNORE_ALL_OPTION);
-		}
+		popupMenu.add(INCLUDE_ALL_OPTION);
+		popupMenu.add(IGNORE_ALL_OPTION);
 
 		this.setComponentPopupMenu(popupMenu);
 	}

--- a/src/main/java/thestonedturtle/bankedexperience/components/GridItem.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/GridItem.java
@@ -28,6 +28,7 @@ import java.awt.Color;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.Collection;
+import java.util.function.Consumer;
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
@@ -47,7 +48,9 @@ import thestonedturtle.bankedexperience.data.modifiers.Modifier;
 public class GridItem extends JLabel
 {
 	private final static String IGNORE = "Ignore Item";
+	private final static String IGNORE_ALL = "Ignore All Items";
 	private final static String INCLUDE = "Include Item";
+	private final static String INCLUDE_ALL = "Include All Items";
 
 	private static final Color UNSELECTED_BACKGROUND = ColorScheme.DARKER_GRAY_COLOR;
 	private static final Color UNSELECTED_HOVER_BACKGROUND = ColorScheme.DARKER_GRAY_HOVER_COLOR;
@@ -73,15 +76,19 @@ public class GridItem extends JLabel
 
 	private final JMenuItem IGNORE_OPTION = new JMenuItem(IGNORE);
 
-	GridItem(final BankedItem item, final AsyncBufferedImage icon, final int amount, final Collection<Modifier> modifiers, final boolean ignore)
+	private final JMenuItem IGNORE_ALL_OPTION = new JMenuItem(IGNORE_ALL);
+
+	private final JMenuItem INCLUDE_ALL_OPTION = new JMenuItem(INCLUDE_ALL);
+
+
+	GridItem(final BankedItem item, final AsyncBufferedImage icon, final int amount, final Collection<Modifier> modifiers, final boolean ignore, Consumer<Boolean> bulkIgnoreCallback)
 	{
 		super("");
 
-		this.ignored = ignore;
+		this.setIgnore(ignore);
 		this.bankedItem = item;
 
 		this.setOpaque(true);
-		this.setBackground(getBackgroundColor());
 		this.setBorder(BorderFactory.createEmptyBorder(5, 0, 2, 0));
 
 		this.setVerticalAlignment(SwingConstants.CENTER);
@@ -135,9 +142,19 @@ public class GridItem extends JLabel
 			setBackground(getBackgroundColor());
 		});
 
+		IGNORE_ALL_OPTION.addActionListener(e -> {
+			bulkIgnoreCallback.accept(true);
+		});
+
+		INCLUDE_ALL_OPTION.addActionListener(e -> {
+			bulkIgnoreCallback.accept(false);
+		});
+
 		final JPopupMenu popupMenu = new JPopupMenu();
 		popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
 		popupMenu.add(IGNORE_OPTION);
+		popupMenu.add(INCLUDE_ALL_OPTION);
+		popupMenu.add(IGNORE_ALL_OPTION);
 
 		this.setComponentPopupMenu(popupMenu);
 	}

--- a/src/main/java/thestonedturtle/bankedexperience/components/SelectionGrid.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/SelectionGrid.java
@@ -67,7 +67,7 @@ public class SelectionGrid extends JPanel
 			final boolean stackable = item.getItem().isStackable() || qty > 1;
 			final AsyncBufferedImage img = itemManager.getImage(item.getItem().getItemID(), qty, stackable);
 
-			final GridItem gridItem = new GridItem(item, img, qty, calc.getEnabledModifiers(), calc.getIgnoredItems().contains(item.getItem().name()), calc::setIgnoreAllItems, calc.getConfig().showBulkActions());
+			final GridItem gridItem = new GridItem(item, img, qty, calc.getEnabledModifiers(), calc.getIgnoredItems().contains(item.getItem().name()), calc::setIgnoreAllItems);
 
 			gridItem.setSelectionListener(new SelectionListener()
 			{

--- a/src/main/java/thestonedturtle/bankedexperience/components/SelectionGrid.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/SelectionGrid.java
@@ -67,7 +67,7 @@ public class SelectionGrid extends JPanel
 			final boolean stackable = item.getItem().isStackable() || qty > 1;
 			final AsyncBufferedImage img = itemManager.getImage(item.getItem().getItemID(), qty, stackable);
 
-			final GridItem gridItem = new GridItem(item, img, qty, calc.getEnabledModifiers(), calc.getIgnoredItems().contains(item.getItem().name()), calc::setIgnoreAllItems);
+			final GridItem gridItem = new GridItem(item, img, qty, calc.getEnabledModifiers(), calc.getIgnoredItems().contains(item.getItem().name()), calc::setIgnoreAllItems, calc.getConfig().showBulkActions());
 
 			gridItem.setSelectionListener(new SelectionListener()
 			{

--- a/src/main/java/thestonedturtle/bankedexperience/components/SelectionGrid.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/SelectionGrid.java
@@ -67,7 +67,7 @@ public class SelectionGrid extends JPanel
 			final boolean stackable = item.getItem().isStackable() || qty > 1;
 			final AsyncBufferedImage img = itemManager.getImage(item.getItem().getItemID(), qty, stackable);
 
-			final GridItem gridItem = new GridItem(item, img, qty, calc.getEnabledModifiers(), calc.getIgnoredItems().contains(item.getItem().name()));
+			final GridItem gridItem = new GridItem(item, img, qty, calc.getEnabledModifiers(), calc.getIgnoredItems().contains(item.getItem().name()), calc::setIgnoreAllItems);
 
 			gridItem.setSelectionListener(new SelectionListener()
 			{


### PR DESCRIPTION
- Adds two new buttons `Include All` and `Ignore All`
  - Wraps them in a panel to display them as a row
  - Bulkifies ignoring / including by iterating over the grid items.
- Adds config to enable / disable buttons

Feel free to close if it's not inline with the vision of this plugin!

![image](https://user-images.githubusercontent.com/39996391/194171031-09e5dd02-a47d-43d8-abc1-99314b31af8f.png)

/edit: Updated image to reflect menu item dropdown 