### PR TITLE
Secondary mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.4'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.slf4j:slf4j-simple:1.7.12'
-    testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion, {
-        exclude group: 'ch.qos.logback', module: 'logback-classic'
-    }
+    testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
 }
 
 group = 'thestonedturtle.bankedexperience'

--- a/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
@@ -180,6 +180,10 @@ public class BankedCalculator extends JPanel
 		open(newSkill, false);
 	}
 
+	void refresh() {
+		open(currentSkill, true);
+	}
+
 	/**
 	 * opens the Banked Calculator for this skill
 	 */

--- a/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedCalculator.java
@@ -59,6 +59,7 @@ import thestonedturtle.bankedexperience.components.SelectionGrid;
 import thestonedturtle.bankedexperience.components.SelectionListener;
 import thestonedturtle.bankedexperience.components.textinput.BoostInput;
 import thestonedturtle.bankedexperience.components.textinput.UICalculatorInputArea;
+import thestonedturtle.bankedexperience.config.SecondaryMode;
 import thestonedturtle.bankedexperience.data.Activity;
 import thestonedturtle.bankedexperience.data.BankedItem;
 import thestonedturtle.bankedexperience.data.ExperienceItem;
@@ -282,9 +283,9 @@ public class BankedCalculator extends JPanel
 			add(modifyPanel);
 			add(itemGrid);
 
-			if (config.showSecondaries())
+			if (config.showWhatSecondaries() != SecondaryMode.NONE)
 			{
-				secondaryGrid = new SecondaryGrid(this, itemGrid.getPanelMap().values());
+				secondaryGrid = new SecondaryGrid(this, itemGrid.getPanelMap().values(), config.showWhatSecondaries());
 				boolean wasClosed = secondarySection != null && !secondarySection.isOpen();
 				secondarySection = new ExpandableSection(
 					"Secondaries",

--- a/src/main/java/thestonedturtle/bankedexperience/BankedCalculatorPanel.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedCalculatorPanel.java
@@ -121,4 +121,8 @@ public class BankedCalculatorPanel extends PluginPanel
 	{
 		calculator.resetInventoryMaps();
 	}
+
+	void refreshCalculator() {
+		calculator.refresh();
+	}
 }

--- a/src/main/java/thestonedturtle/bankedexperience/BankedExperienceConfig.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedExperienceConfig.java
@@ -32,7 +32,7 @@ public interface BankedExperienceConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "showWhatSecondaries",
+			keyName = BankedExperiencePlugin.SECONDARY_SHOW_MODE_KEY,
 			name = "Show secondaries",
 			description = "Toggles whether any, required or all secondaries will be displayed for the selected items",
 			position = 2
@@ -54,7 +54,7 @@ public interface BankedExperienceConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "grabFromSeedVault",
+		keyName = BankedExperiencePlugin.VAULT_CONFIG_KEY,
 		name = "Include seed vault",
 		description = "Toggles whether the items stored inside the Seed Vault at the Farming Guild will be included in the calculations",
 		position = 4
@@ -65,7 +65,7 @@ public interface BankedExperienceConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "grabFromInventory",
+		keyName = BankedExperiencePlugin.INVENTORY_CONFIG_KEY,
 		name = "Include player inventory",
 		description = "Toggles whether the items inside your inventory will be included in the calculations",
 		position = 5
@@ -76,7 +76,7 @@ public interface BankedExperienceConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "grabFromLootingBag",
+		keyName = BankedExperiencePlugin.LOOTING_BAG_CONFIG_KEY,
 		name = "Include looting bag",
 		description = "Toggles whether the items stored inside your Looting Bag will be included in the calculations",
 		position = 6
@@ -87,7 +87,7 @@ public interface BankedExperienceConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "grabFromFossilChest",
+		keyName = BankedExperiencePlugin.FOSSIL_CHEST_CONFIG_KEY,
 		name = "Include Fossil Chest",
 		description = "Toggles whether the fossils stored inside your Fossil Island chest will be included in the calculations",
 		position = 7

--- a/src/main/java/thestonedturtle/bankedexperience/BankedExperienceConfig.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedExperienceConfig.java
@@ -3,6 +3,7 @@ package thestonedturtle.bankedexperience;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import thestonedturtle.bankedexperience.config.SecondaryMode;
 
 @ConfigGroup("bankedexperience")
 public interface BankedExperienceConfig extends Config
@@ -18,15 +19,27 @@ public interface BankedExperienceConfig extends Config
 		return true;
 	}
 
+	//No longer used, kept alive for migration purposes.
 	@ConfigItem(
 		keyName = "showSecondaries",
-		name = "Show required secondaries",
-		description = "Toggles whether the Secondaries will be displayed for the selected item",
-		position = 2
+		name = "",
+		description = "",
+		hidden = true
 	)
 	default boolean showSecondaries()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+			keyName = "showWhatSecondaries",
+			name = "Show secondaries",
+			description = "Toggles whether any, required or all secondaries will be displayed for the selected items",
+			position = 2
+	)
+	default SecondaryMode showWhatSecondaries()
+	{
+		return showSecondaries() ? SecondaryMode.ALL : SecondaryMode.NONE;
 	}
 
 	@ConfigItem(

--- a/src/main/java/thestonedturtle/bankedexperience/BankedExperiencePlugin.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedExperiencePlugin.java
@@ -41,10 +41,11 @@ public class BankedExperiencePlugin extends Plugin
 	private static final BufferedImage ICON = ImageUtil.loadImageResource(BankedExperiencePlugin.class, "banked.png");
 	private static final Map<Integer, Integer> EMPTY_MAP = new HashMap<>();
 	public static final String CONFIG_GROUP = "bankedexperience";
-	private static final String VAULT_CONFIG_KEY = "grabFromSeedVault";
-	private static final String INVENTORY_CONFIG_KEY = "grabFromInventory";
-	private static final String LOOTING_BAG_CONFIG_KEY = "grabFromLootingBag";
-	private static final String FOSSIL_CHEST_CONFIG_KEY = "grabFromFossilChest";
+	public static final String VAULT_CONFIG_KEY = "grabFromSeedVault";
+	public static final String INVENTORY_CONFIG_KEY = "grabFromInventory";
+	public static final String LOOTING_BAG_CONFIG_KEY = "grabFromLootingBag";
+	public static final String FOSSIL_CHEST_CONFIG_KEY = "grabFromFossilChest";
+	public static final String SECONDARY_SHOW_MODE_KEY = "showWhatSecondaries";
 	public static final String ACTIVITY_CONFIG_KEY = "ITEM_";
 	private static final int LOOTING_BAG_ID = 516;
 

--- a/src/main/java/thestonedturtle/bankedexperience/BankedExperiencePlugin.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedExperiencePlugin.java
@@ -156,6 +156,9 @@ public class BankedExperiencePlugin extends Plugin
 			case FOSSIL_CHEST_CONFIG_KEY:
 				inventoryId = WidgetInventoryInfo.FOSSIL_CHEST.getId();
 				break;
+			case SECONDARY_SHOW_MODE_KEY:
+				panel.refreshCalculator();
+				return;
 			default:
 				return;
 		}

--- a/src/main/java/thestonedturtle/bankedexperience/components/SecondaryGrid.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/SecondaryGrid.java
@@ -132,6 +132,7 @@ public class SecondaryGrid extends JPanel
 
 			final String tooltip = "<html>" + itemName
 				+ "<br/>Banked: " + BankedCalculator.XP_FORMAT_COMMA.format(available)
+				+ (mode == SecondaryMode.MISSING ? "<br/>Needed: " + BankedCalculator.XP_FORMAT_COMMA.format(qty) : "")
 				+ "<br/>Result: " + (result > 0 ? "+" : "") + BankedCalculator.XP_FORMAT_COMMA.format(result)
 				+ "<br/>" + resources.toString() + "</html>";
 			label.setToolTipText(tooltip);

--- a/src/main/java/thestonedturtle/bankedexperience/components/SecondaryGrid.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/SecondaryGrid.java
@@ -233,17 +233,4 @@ public class SecondaryGrid extends JPanel
 
 		refreshUI();
 	}
-
-	@Subscribe
-	public void onConfigChanged(ConfigChanged event)
-	{
-		if (!event.getGroup().equals(BankedExperiencePlugin.CONFIG_GROUP)) {
-			return;
-		}
-		if (!event.getKey().equals(BankedExperiencePlugin.SECONDARY_SHOW_MODE_KEY)) {
-			return;
-		}
-		mode = SecondaryMode.valueOf(event.getNewValue());
-		refreshUI();
-	}
 }

--- a/src/main/java/thestonedturtle/bankedexperience/components/SecondaryGrid.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/SecondaryGrid.java
@@ -39,8 +39,11 @@ import lombok.Getter;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ItemID;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.ui.ColorScheme;
 import thestonedturtle.bankedexperience.BankedCalculator;
+import thestonedturtle.bankedexperience.BankedExperiencePlugin;
 import thestonedturtle.bankedexperience.config.SecondaryMode;
 import thestonedturtle.bankedexperience.data.Activity;
 import thestonedturtle.bankedexperience.data.BankedItem;
@@ -64,7 +67,7 @@ public class SecondaryGrid extends JPanel
 	private final Map<Integer, Integer> availableMap = new HashMap<>();
 	private final BankedCalculator calc;
 
-	private final SecondaryMode mode;
+	private SecondaryMode mode;
 
 	public SecondaryGrid(final BankedCalculator calc, final Collection<GridItem> items, SecondaryMode mode)
 	{
@@ -75,9 +78,14 @@ public class SecondaryGrid extends JPanel
 		updateSecMap(items);
 	}
 
-	private void refreshUI()
+	public void refreshUI()
 	{
 		removeAll();
+
+		if(mode == SecondaryMode.NONE) {
+			return;
+		}
+
 		for (final int itemID : secMap.keySet())
 		{
 			final JLabel label = new JLabel();
@@ -222,6 +230,19 @@ public class SecondaryGrid extends JPanel
 			}
 		}
 
+		refreshUI();
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (!event.getGroup().equals(BankedExperiencePlugin.CONFIG_GROUP)) {
+			return;
+		}
+		if (!event.getKey().equals(BankedExperiencePlugin.SECONDARY_SHOW_MODE_KEY)) {
+			return;
+		}
+		mode = SecondaryMode.valueOf(event.getNewValue());
 		refreshUI();
 	}
 }

--- a/src/main/java/thestonedturtle/bankedexperience/components/SecondaryGrid.java
+++ b/src/main/java/thestonedturtle/bankedexperience/components/SecondaryGrid.java
@@ -41,6 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ItemID;
 import net.runelite.client.ui.ColorScheme;
 import thestonedturtle.bankedexperience.BankedCalculator;
+import thestonedturtle.bankedexperience.config.SecondaryMode;
 import thestonedturtle.bankedexperience.data.Activity;
 import thestonedturtle.bankedexperience.data.BankedItem;
 import thestonedturtle.bankedexperience.data.ItemInfo;
@@ -63,9 +64,12 @@ public class SecondaryGrid extends JPanel
 	private final Map<Integer, Integer> availableMap = new HashMap<>();
 	private final BankedCalculator calc;
 
-	public SecondaryGrid(final BankedCalculator calc, final Collection<GridItem> items)
+	private final SecondaryMode mode;
+
+	public SecondaryGrid(final BankedCalculator calc, final Collection<GridItem> items, SecondaryMode mode)
 	{
 		this.calc = calc;
+		this.mode = mode;
 		setLayout(new GridLayout(0, 5, 1, 1));
 
 		updateSecMap(items);
@@ -100,12 +104,23 @@ public class SecondaryGrid extends JPanel
 					.append(" x ")
 					.append(info.getBankedItem().getItem().getItemInfo().getName());
 			}
-			calc.getItemManager().getImage(itemID, (int) Math.round(qty), qty > 0).addTo(label);
 
 			final ItemInfo info = infoMap.get(itemID);
 			final String itemName = info == null ? "" : info.getName();
 			final int available = availableMap.getOrDefault(itemID, 0);
 			final double result = available - qty;
+
+			if (mode == SecondaryMode.ALL) {
+				calc.getItemManager().getImage(itemID, (int) Math.round(qty), qty > 0).addTo(label);
+			} else {
+				if(result < 0) {
+					//use the flipped result such that the right icon gets applied and text styling gets applied.
+					calc.getItemManager().getImage(itemID, -1 * (int) Math.round(result), true).addTo(label);
+				} else {
+					//skip if we don't need this secondary.
+					continue;
+				}
+			}
 
 			final String tooltip = "<html>" + itemName
 				+ "<br/>Banked: " + BankedCalculator.XP_FORMAT_COMMA.format(available)

--- a/src/main/java/thestonedturtle/bankedexperience/config/SecondaryMode.java
+++ b/src/main/java/thestonedturtle/bankedexperience/config/SecondaryMode.java
@@ -1,0 +1,20 @@
+package thestonedturtle.bankedexperience.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SecondaryMode {
+    NONE("None"),
+    ALL("All"),
+    MISSING("Needed");
+
+    private final String name;
+
+    @Override
+    public String toString()
+    {
+        return name;
+    }
+}


### PR DESCRIPTION
Fixes #111 
Changes the config option for show secondaries to also have a show missing secondaries only mode.
![a](https://cdn.discordapp.com/attachments/132978900841136139/1151211171093942292/image.png)
![c](https://cdn.discordapp.com/attachments/132978900841136139/1151211171660189786/image.png)
The old display is still supported (and probably preferred for most users)
![d](https://cdn.discordapp.com/attachments/132978900841136139/1151211171949580298/image.png)

Currently still in draft as I need to fix the secondary grid display not redrawing/reloading if the config option is changed.

Thank you @DrJam for supplying the images.