### PR TITLE
Feature: Add hide maxed skills configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,15 @@ Items that take multiple steps have their Activities split between the different
 Like most plugins the Banked Experience plugin includes some config options to help customize its functionality.
 See the relative section for each config option for an in-depth description.
 
-| Name 														| Enabled by Default|
-| :--- 														| :-----: |
-| [Include output items](#include-output-items)				| &check; |
-| [Show required secondaries](#show-required-secondaries)	| X |
-| [Respect level requirements](#respect-level-requirements)	| &check; |
-| [Include seed vault](#include-seed-vault)					| &check; |
-| [Include player inventory](#include-player-inventory)		| X |
-| [Include looting bag](#include-looting-bag)				| X |
+| Name 														                                        | Enabled by Default|
+|:-----------------------------------------------------------| :-----: |
+| [Include output items](#include-output-items)				          | &check; |
+| [Show required secondaries](#show-required-secondaries)	   | X |
+| [Respect level requirements](#respect-level-requirements)	 | &check; |
+| [Include seed vault](#include-seed-vault)					             | &check; |
+| [Include player inventory](#include-player-inventory)		    | X |
+| [Include looting bag](#include-looting-bag)				            | X |
+| [Show maxed level skills](#show-maxed-level-skills)				    | &check; |
 
 
 ### Include output items
@@ -111,6 +112,18 @@ This option is **Disabled** by default
 
 Controls whether the items stored inside your Looting Bag will be included in the calculations.
 This feature requires checking your looting bag, using items on it or picking up items while its opened does not work.
+</p>
+</details>
+
+### Show maxed level skills
+<details>
+<summary>Details</summary>
+<p>
+
+This option is **Enabled** by default
+
+Toggles whether to show skills that are level 99 in the menu of selectable skills. 
+If enabled it will show these skills, if disabled it will hide these skills. 
 </p>
 </details>
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'java'
-    id 'checkstyle'
 }
 
 repositories {
@@ -16,8 +15,8 @@ def runeLiteVersion = 'latest.release'
 dependencies {
     compileOnly group: 'net.runelite', name: 'client', version: runeLiteVersion
 
-    compileOnly 'org.projectlombok:lombok:1.18.4'
-    annotationProcessor 'org.projectlombok:lombok:1.18.4'
+    compileOnly 'org.projectlombok:lombok:1.18.38'
+    annotationProcessor 'org.projectlombok:lombok:1.18.38'
 
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.slf4j:slf4j-simple:1.7.12'
@@ -34,6 +33,3 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
-checkstyle {
-    configDirectory = file('./')
-}

--- a/src/main/java/thestonedturtle/bankedexperience/BankedCalculatorPanel.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedCalculatorPanel.java
@@ -30,6 +30,7 @@ import java.awt.GridBagLayout;
 import java.awt.event.ItemEvent;
 import java.awt.image.BufferedImage;
 import java.util.Map;
+import java.util.Set;
 import javax.swing.ImageIcon;
 import javax.swing.JComboBox;
 import javax.swing.border.EmptyBorder;
@@ -50,11 +51,15 @@ import thestonedturtle.bankedexperience.data.Activity;
 public class BankedCalculatorPanel extends PluginPanel
 {
 	private final BankedCalculator calculator;
+	private final JComboBox<ComboBoxIconEntry> dropdown = new JComboBox<>();
+	private final SkillIconManager skillIconManager;
 
 	public BankedCalculatorPanel(Client client, BankedExperienceConfig config, SkillIconManager skillIconManager,
 								ItemManager itemManager, ConfigManager configManager)
 	{
 		super();
+
+		this.skillIconManager = skillIconManager;
 
 		setBorder(new EmptyBorder(10, 10, 10, 10));
 		setLayout(new GridBagLayout());
@@ -68,36 +73,7 @@ public class BankedCalculatorPanel extends PluginPanel
 
 		calculator = new BankedCalculator(inputs, client, config, itemManager, configManager);
 
-		// Create the Skill dropdown with icons
-		final JComboBox<ComboBoxIconEntry> dropdown = new JComboBox<>();
-		dropdown.setFocusable(false); // To prevent an annoying "focus paint" effect
-		dropdown.setForeground(Color.WHITE);
-		dropdown.setMaximumRowCount(Activity.BANKABLE_SKILLS.size());
-		final ComboBoxIconListRenderer renderer = new ComboBoxIconListRenderer();
-		renderer.setDefaultText("Select a Skill...");
-		dropdown.setRenderer(renderer);
-
-		for (final Skill skill : Activity.BANKABLE_SKILLS)
-		{
-			final BufferedImage img = skillIconManager.getSkillImage(skill, true);
-			final ComboBoxIconEntry entry = new ComboBoxIconEntry(new ImageIcon(img), skill.getName(), skill);
-			dropdown.addItem(entry);
-		}
-
-		dropdown.addItemListener(e ->
-		{
-			if (e.getStateChange() == ItemEvent.SELECTED)
-			{
-				final ComboBoxIconEntry source = (ComboBoxIconEntry) e.getItem();
-				if (source.getData() instanceof Skill)
-				{
-					final Skill skill = (Skill) source.getData();
-					this.calculator.open(skill);
-				}
-			}
-		});
-
-		dropdown.setSelectedIndex(-1);
+		showSkills(Activity.BANKABLE_SKILLS);
 
 		final GridBagConstraints c = new GridBagConstraints();
 		c.fill = GridBagConstraints.HORIZONTAL;
@@ -120,5 +96,44 @@ public class BankedCalculatorPanel extends PluginPanel
 	void resetInventoryMaps()
 	{
 		calculator.resetInventoryMaps();
+	}
+
+	/**
+	 * Create the Skill dropdown with icons
+	 * @param skills
+	 */
+	public void showSkills(final Set<Skill> skills) {
+		dropdown.removeAll();
+		dropdown.setFocusable(false); // To prevent an annoying "focus paint" effect
+		dropdown.setForeground(Color.WHITE);
+		dropdown.setMaximumRowCount(skills.size());
+		final ComboBoxIconListRenderer renderer = new ComboBoxIconListRenderer();
+		renderer.setDefaultText("Select a Skill...");
+		dropdown.setRenderer(renderer);
+
+		for (final Skill skill : skills)
+		{
+			final BufferedImage img = skillIconManager.getSkillImage(skill, true);
+			final ComboBoxIconEntry entry = new ComboBoxIconEntry(new ImageIcon(img), skill.getName(), skill);
+			dropdown.addItem(entry);
+		}
+
+		dropdown.addItemListener(e ->
+    {
+      if (e.getStateChange() == ItemEvent.SELECTED)
+      {
+        final ComboBoxIconEntry source = (ComboBoxIconEntry) e.getItem();
+        if (source.getData() instanceof Skill)
+        {
+          final Skill skill = (Skill) source.getData();
+          this.calculator.open(skill);
+        }
+      }
+    });
+
+		dropdown.setSelectedIndex(-1);
+
+		revalidate();
+		repaint();
 	}
 }

--- a/src/main/java/thestonedturtle/bankedexperience/BankedExperienceConfig.java
+++ b/src/main/java/thestonedturtle/bankedexperience/BankedExperienceConfig.java
@@ -8,6 +8,8 @@ import net.runelite.client.config.ConfigItem;
 public interface BankedExperienceConfig extends Config
 {
 	String POTION_STORAGE_KEY = "grabFromPotionStorage";
+	String SHOW_MAXED_LEVELS_CONFIG_KEY = "showMaxedLevels";
+
 
 	@ConfigItem(
 		keyName = "cascadeBankedXp",
@@ -93,6 +95,16 @@ public interface BankedExperienceConfig extends Config
 		position = 7
 	)
 	default boolean grabFromPotionStorage()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = SHOW_MAXED_LEVELS_CONFIG_KEY,
+			name = "Show maxed level skills",
+			description = "Toggles whether skills that are level 99 should be shown in the list of banked skills"
+	)
+	default boolean showMaxedLevelSkills()
 	{
 		return true;
 	}


### PR DESCRIPTION
I was playing around with the idea to hide maxed skills from the skill dropdown menu. Still some work left in correctly re-rendering the dropdown, but should be as simple as adding a config and filtering the list once the player has logged in.

Definitely still WIP. 
Before I continue spending time on it, what do you think of adding a feature like this @TheStonedTurtle ?