### PR TITLE
fix: Fix amethyst item mappings

### DIFF
--- a/src/main/java/thestonedturtle/bankedexperience/data/Activity.java
+++ b/src/main/java/thestonedturtle/bankedexperience/data/Activity.java
@@ -1053,9 +1053,9 @@ public enum Activity
 	AMETHYST_ARROWTIPS(ItemID.AMETHYST_ARROWTIPS, "Amethyst arrowtips", 85, 60,
 		ExperienceItem.AMETHYST, null, new ItemStack(ItemID.AMETHYST_ARROWTIPS, 15)),
 	AMETHYST_JAVELIN_HEADS(ItemID.AMETHYST_JAVELIN_HEADS, "Amethyst javelin heads", 87, 60,
-		ExperienceItem.AMETHYST, null, new ItemStack(ItemID.AMETHYST_BOLT_TIPS, 5)),
+		ExperienceItem.AMETHYST, null, new ItemStack(ItemID.AMETHYST_JAVELIN_HEADS, 5)),
 	AMETHYST_DART_TIP(ItemID.AMETHYST_DART_TIP, "Amethyst dart tips", 89, 60,
-		ExperienceItem.AMETHYST, null, new ItemStack(ItemID.AMETHYST_BOLT_TIPS, 8)),
+		ExperienceItem.AMETHYST, null, new ItemStack(ItemID.AMETHYST_DART_TIP, 8)),
 	// RNG section
 	// Soda Ash
 	MOLTEN_GLASS(ItemID.MOLTEN_GLASS, "Furnace", 1, 20,


### PR DESCRIPTION
I was looking at the plugin today and noticed that some of the mappings are broken for amethyst crafting. First, the output quantities for both the javelin head and the dart tips are incorrectly displaying 1 in the dropdown:

<img width="260" height="300" alt="Screenshot 2025-08-22 at 7 34 41 PM" src="https://github.com/user-attachments/assets/5fd93ba2-f1f1-4cfa-a8de-e2dfd5fff737" />

Next, I realized that when they're selected, both the javelin heads and dart tips are incorrectly displaying "Amethyst bolt tips" for their images, despite using the correct image.

<img width="236" height="194" alt="Screenshot 2025-08-22 at 7 35 21 PM" src="https://github.com/user-attachments/assets/0cc36635-14c4-49d1-a275-20ec5803b2b5" />

<img width="234" height="193" alt="Screenshot 2025-08-22 at 7 35 05 PM" src="https://github.com/user-attachments/assets/1c8056e7-b921-45e9-b5cc-23f34afb3cdc" />

The outputs for the total quantities are correct for all of them though.

I haven't looked too deeply into how this plugin works (Java isn't my best language haha), but I did find the places where the amethyst item activities are being defined. I discovered that both of these items are incorrectly mapping to the bolt tips for their `ItemStack`. So I just updated it to reference their own item IDs for the item stack.

I've never developed a runelite extension before and wasn't able to test this locally, so I have no idea if this will fix both of the issues mentioned above. But I'd imagine it would at least fix the incorrect name mapping. The displayed 1 for the quantity is still confusing me though haha. You could probably tell better than me whether that is caused by the same incorrect item ID.